### PR TITLE
Updated the JSONField references to use the Django database-agnostic JSONField introduced in 3.0

### DIFF
--- a/feedback/models.py
+++ b/feedback/models.py
@@ -161,7 +161,7 @@ class ElementType(models.Model):
     """
     name = models.CharField(max_length=250, null=False, blank=False)
     key = models.CharField(max_length=30, null=False, blank=False)
-    options = fields.JSONField(default=dict)
+    options = models.JSONField(default=dict)
 
     class Meta:
         managed = MANAGED_MODELS
@@ -189,7 +189,7 @@ class FormElement(BaseFeedbackModel):
     name = models.CharField(max_length=250, null=False, blank=False)
     label = models.CharField(max_length=1000, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
-    options = fields.JSONField(default=dict, blank=True)
+    options = models.JSONField(default=dict, blank=True)
     order = models.SmallIntegerField(default=0)
 
     class Meta:
@@ -320,7 +320,7 @@ class FeedbackData(BaseFeedbackModel):
     """
     collection = models.ForeignKey(FeedbackCollection, null=False, blank=False, on_delete=models.PROTECT)
     element = models.ForeignKey(FormElement, null=False, blank=False, on_delete=models.PROTECT)
-    value = fields.JSONField(null=True, blank=True)
+    value = models.JSONField(null=True, blank=True)
 
     class Meta:
         managed = MANAGED_MODELS


### PR DESCRIPTION
This will resolve depreciation warnings when importing this module from a Django 3.X installation, and resolve unrecoverable errors when importing from a Django 4.X installation